### PR TITLE
[Quick Fix] Serve static files

### DIFF
--- a/frontend/pages/users.py
+++ b/frontend/pages/users.py
@@ -1,19 +1,11 @@
-import asyncio
-from cProfile import label
-import json
-from black import click
-from idom import html, run, use_state, component, event, vdom
-import requests
-from sanic import Sanic, response
+from idom import html, use_state, component, event
 from datetime import datetime
 
 from pages.utils import switch_state
 from components.input import Input, Selector2
 from components.layout import Row, Column, Container
-from components.lists import ListSimple
 from components.table import SimpleTable
 from components.controls import Button
-from config import base_url
 
 from data.users import (
     to_user,

--- a/frontend/run_app.py
+++ b/frontend/run_app.py
@@ -1,10 +1,15 @@
 import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.staticfiles import StaticFiles
 from idom.server import fastapi
+from idom.server.starlette import Options
+from pathlib import Path
 from index import page as index_page
 
 app = fastapi.create_development_app()
-
-fastapi.configure(app, index_page)
+HERE = Path(__file__).parent
+app.mount("/static", StaticFiles(directory=str(HERE)), name="static")
+fastapi.configure(app, index_page, Options(redirect_root=False))
 
 
 def run():


### PR DESCRIPTION
Previous implementation of serving app through FastAPI didn't serve static files. Fixed in this PR.