### PR TITLE
[Quickfix] Close connections and increase pool size of engine

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -79,3 +79,4 @@ def implement_calendar_table():
             with engine.connect() as con:
                 con.execute(text(values_sql))
                 con.commit()
+                con.close()

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,11 +1,9 @@
 from typing import Optional
-from sqlmodel import Field, SQLModel, Field, MetaData, create_engine
+from sqlmodel import Field, SQLModel, Field
 from pydantic import validator
 from datetime import datetime, date
 from fastapi import HTTPException
 import re
-
-engine = create_engine("postgresql://pguser:password@db:5432/test_db", echo=True)
 
 
 class AppUser(SQLModel, table=True):

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -25,7 +25,7 @@ def create_connection_str():
 con_str = create_connection_str()
 
 # Create the engine to be used to enter data into the database
-engine = create_engine(con_str, echo=True)
+engine = create_engine(con_str, echo=True, pool_size=10)
 
 
 def get_session():
@@ -39,6 +39,7 @@ def create_db():
             if not conn.dialect.has_schema(conn, "app_db"):
                 conn.execute(CreateSchema("app_db"))
                 conn.commit()
+                conn.close()
     SQLModel.metadata.create_all(engine)
 
 


### PR DESCRIPTION
SQLAlchemy was reaching a bottleneck when multiple SQL statements were thrown at the timelogs model, causing the app to crash. 
Thus pool size was increased, however we will likely need to refactor our execute statements to make sure that we are closing connections once our SQL statements are ran.