### PR TITLE
Remove 'False' returned by |Simple Table| component

### DIFF
--- a/uiflow/components/table.py
+++ b/uiflow/components/table.py
@@ -70,9 +70,9 @@ def SimpleTable(rows: List[Any]):
             ),
         )
     except TypeError:
-        return False
+        return html.div()
     except IndexError:
-        return False
+        return html.div()
 
 
 @component


### PR DESCRIPTION
- SimpleTable return now empty container `<div></div>`
- closes https://github.com/dyvenia/timeflow/issues/201