### PR TITLE
Multiple timelogs id bug fix

### DIFF
--- a/applications/timeflow/data/epic_areas.py
+++ b/applications/timeflow/data/epic_areas.py
@@ -47,6 +47,15 @@ def epic_areas_names() -> List[Select]:
         epic_area_name_rows.append(d)
     return epic_area_name_rows
 
+def epic_areas_names_by_epic_id(epic_id) -> List[Select]:
+    api = f"{base_url}/api/epic_areas"
+    params = {"epic_id": epic_id}
+    response = requests.get(api, params=params)
+    rows = [Select(value="", display_value="select epic area")]
+    for item in response.json():
+        d = Select(value=item["id"], display_value=item["epic_area_name"])
+        rows.append(d)
+    return rows
 
 def post_epic_area(epic_id: int, name: str):
     data = {

--- a/applications/timeflow/data/timelogs.py
+++ b/applications/timeflow/data/timelogs.py
@@ -56,6 +56,7 @@ def timelog_by_user_epic_year_month(user_id, epic_id, year, month) -> List[Dict]
                 "timelog id": item["id"],
                 "username": item["username"],
                 "epic name": item["epic_name"],
+                "epic area name": item["epic_area_name"],
                 "start time": (item["start_time"]).replace("T", " "),
                 "end time": (item["end_time"]).replace("T", " "),
                 "count hours": item["count_hours"],

--- a/applications/timeflow/data/timelogs.py
+++ b/applications/timeflow/data/timelogs.py
@@ -9,6 +9,7 @@ class Timelog(TypedDict):
     end_time: str
     user_id: int
     epic_id: int
+    epic_area_id: int
     count_hours: float
     count_days: float
     month: int
@@ -21,8 +22,6 @@ def to_timelog(
     user_id: int,
     epic_id: int,
     epic_area_id: int,
-    count_hours: float,
-    count_days: float,
     month: int,
     year: int,
 ) -> bool:
@@ -31,17 +30,18 @@ def to_timelog(
         end_time=end_time,
         user_id=user_id,
         epic_id=epic_id,
+        epic_area_id=epic_area_id,
         count_hours=0,
         count_days=0,
         month=str(month),
         year=str(year),
-        epic_area_id=epic_area_id,
     )
     response = requests.post(
         f"{base_url}/api/timelogs",
         data=json.dumps(dict(data)),
         headers={"accept": "application/json", "Content-Type": "application/json"},
     )
+    print(data)
     return True
 
 

--- a/applications/timeflow/data/timelogs.py
+++ b/applications/timeflow/data/timelogs.py
@@ -9,39 +9,37 @@ class Timelog(TypedDict):
     end_time: str
     user_id: int
     epic_id: int
-    epic_area_id: int
     count_hours: float
     count_days: float
     month: int
     year: int
-
+    epic_area_id: int
 
 def to_timelog(
     start_time: str,
     end_time: str,
     user_id: int,
     epic_id: int,
-    epic_area_id: int,
     month: int,
     year: int,
+    epic_area_id: int,
 ) -> bool:
     data = Timelog(
+        user_id=user_id,
         start_time=start_time,
         end_time=end_time,
-        user_id=user_id,
         epic_id=epic_id,
-        epic_area_id=epic_area_id,
         count_hours=0,
         count_days=0,
         month=str(month),
         year=str(year),
+        epic_area_id=epic_area_id,
     )
     response = requests.post(
         f"{base_url}/api/timelogs",
         data=json.dumps(dict(data)),
         headers={"accept": "application/json", "Content-Type": "application/json"},
     )
-    print(data)
     return True
 
 
@@ -63,5 +61,4 @@ def timelog_by_user_epic_year_month(user_id, epic_id, year, month) -> List[Dict]
                 "count days": item["count_days"],
             }
             rows.append(d)
-        print(rows)
         return rows

--- a/applications/timeflow/pages/timelogs.py
+++ b/applications/timeflow/pages/timelogs.py
@@ -99,7 +99,6 @@ def create_timelog_form(
     "year": 0
     }
     """
-
     @event(prevent_default=True)
     async def handle_submit(event):
         a = year_month

--- a/applications/timeflow/pages/timelogs.py
+++ b/applications/timeflow/pages/timelogs.py
@@ -18,7 +18,7 @@ from ..data.common import (
 
 from ..data.timelogs import to_timelog, timelog_by_user_epic_year_month
 from ..data.epics import epics_names
-from ..data.epic_areas import epic_areas_names
+from ..data.epic_areas import epic_areas_names, epic_areas_names_by_epic_id
 
 from ..config import base_url
 from uiflow.components.controls import TableActions
@@ -30,7 +30,7 @@ def page():
     year_month, set_year_month = use_state("")
     day, set_day = use_state("")
     user_id, set_user_id = use_state("")
-    epic_id, set_epic_id = use_state("")
+    epic_id, set_epic_id = use_state(0)
     epic_area_id, set_epic_area_id = use_state("")
     start_time, set_start_time = use_state("")
     end_time, set_end_time = use_state("")
@@ -106,8 +106,6 @@ def create_timelog_form(
         year = a[:4]
         month = a[5:7]
 
-        # year_int = int(year)
-        # month_int = int(month)
         start_time_post = f"{year}-{month}-{day} {start_time}"
         end_time_post = f"{year}-{month}-{day} {end_time}"
 
@@ -117,8 +115,6 @@ def create_timelog_form(
             user_id=user_id,
             epic_id=epic_id,
             epic_area_id=epic_area_id,
-            count_hours=0,
-            count_days=0,
             month=month,
             year=year,
         )
@@ -135,7 +131,7 @@ def create_timelog_form(
     )
     selector_epic_area_id = Selector2(
         set_value=set_epic_area_id,
-        data=epic_areas_names(),
+        data=epic_areas_names_by_epic_id(epic_id),
     )
     selector_year_month = Selector2(
         set_value=set_year_month,

--- a/backend/api/epic_area.py
+++ b/backend/api/epic_area.py
@@ -38,7 +38,7 @@ async def post_epic_area(
 
 
 @router.get("/")
-async def get_epic_areas_list(session: Session = Depends(get_session)):
+async def get_epic_areas_list(epic_id, session: Session = Depends(get_session)):
     """
     Get list of epic areas.
 
@@ -48,8 +48,16 @@ async def get_epic_areas_list(session: Session = Depends(get_session)):
         SQL session that is to be used to get a list of the epic areas.
         Defaults to creating a dependency on the running SQL model session.
     """
-
-    statement = select(EpicArea)
+    if epic_id != None:
+        statement = select(
+            EpicArea.id,
+            EpicArea.epic_id,
+            EpicArea.name.label("epic_area_name"),
+            Epic.id,
+            Epic.name.label("epic_name"),
+        ).join(Epic).where(EpicArea.is_active == True).where(EpicArea.epic_id == epic_id)
+    else:
+        statement = select(EpicArea)
     results = session.exec(statement).all()
     return results
 

--- a/backend/api/timelog.py
+++ b/backend/api/timelog.py
@@ -93,8 +93,8 @@ async def get_timelogs_all(session: Session = Depends(get_session)):
             TimeLog.count_days,
         )
         .join(AppUser)
-        .join(Epic)
         .join(EpicArea)
+        .join(Epic)
         .order_by(TimeLog.end_time.desc())
     )
     results = session.exec(statement).all()
@@ -153,8 +153,8 @@ async def get_timelog_user_id(
             TimeLog.count_days,
         )
         .join(AppUser)
-        .join(Epic)
         .join(EpicArea)
+        .join(Epic)
         .where(TimeLog.user_id == user_id)
         .where(TimeLog.epic_id == epic_id)
         .where(TimeLog.month == month)

--- a/backend/api/timelog.py
+++ b/backend/api/timelog.py
@@ -146,6 +146,7 @@ async def get_timelog_user_id(
             TimeLog.id,
             AppUser.username.label("username"),
             Epic.short_name.label("epic_name"),
+            EpicArea.name.label("epic_area_name"),
             TimeLog.start_time,
             TimeLog.end_time,
             TimeLog.count_hours,
@@ -153,6 +154,7 @@ async def get_timelog_user_id(
         )
         .join(AppUser)
         .join(Epic)
+        .join(EpicArea)
         .where(TimeLog.user_id == user_id)
         .where(TimeLog.epic_id == epic_id)
         .where(TimeLog.month == month)


### PR DESCRIPTION
- fixed duplicated entries issue by changing joins order
- added selector parent relation in timelogs page, now you have to select epic first to be able to select epic area
- removed unnecessary prints