### PR TITLE
|Pages||All| Username Selector visible only for admin #270

### DIFF
--- a/applications/timeflow/config.py
+++ b/applications/timeflow/config.py
@@ -1,4 +1,5 @@
 from idom.backend import fastapi
+from idom import component
 
 
 base_url = "http://fastapi:8002"

--- a/applications/timeflow/data/capacities.py
+++ b/applications/timeflow/data/capacities.py
@@ -60,7 +60,6 @@ def capacities_by_user_team_year_month(user_id, team_id, year_month) -> List[Dic
                 "capacity days": item["days"],
             }
             rows.append(d)
-        print(rows)
         return rows
 
 

--- a/applications/timeflow/data/common.py
+++ b/applications/timeflow/data/common.py
@@ -8,7 +8,6 @@ from ..pages.utils import (
     month_start_list,
     days_in_month_list,
 )
-from uiflow.components.controls import Button
 
 
 class Select(TypedDict):

--- a/applications/timeflow/data/demands.py
+++ b/applications/timeflow/data/demands.py
@@ -60,7 +60,6 @@ def demands_by_team_epic_year_month(team_id, epic_id, year_month) -> List[Dict]:
                 "demand days": item["days"],
             }
             rows.append(d)
-        print(rows)
         return rows
 
 

--- a/applications/timeflow/data/epic_areas.py
+++ b/applications/timeflow/data/epic_areas.py
@@ -47,6 +47,7 @@ def epic_areas_names() -> List[Select]:
         epic_area_name_rows.append(d)
     return epic_area_name_rows
 
+
 def epic_areas_names_by_epic_id(epic_id) -> List[Select]:
     api = f"{base_url}/api/epic_areas"
     if epic_id == "":
@@ -59,6 +60,7 @@ def epic_areas_names_by_epic_id(epic_id) -> List[Select]:
         rows.append(d)
     return rows
 
+
 def post_epic_area(epic_id: int, name: str):
     data = {
         "epic_id": epic_id,
@@ -67,7 +69,6 @@ def post_epic_area(epic_id: int, name: str):
         "created_at": str(datetime.now()),
         "updated_at": str(datetime.now()),
     }
-    print("here", data)
     response = requests.post(
         f"{base_url}/api/epic_areas",
         data=json.dumps(data),

--- a/applications/timeflow/data/forecasts.py
+++ b/applications/timeflow/data/forecasts.py
@@ -96,7 +96,6 @@ def to_forecast(user_id: int, epic_id: int, month: str, year: str, days: int) ->
         updated_at=str(datetime.now()),
         is_locked=False,
     )
-    print(dict(data))
     response = requests.post(
         f"{base_url}/api/forecasts",
         data=json.dumps(dict(data)),

--- a/applications/timeflow/data/rates.py
+++ b/applications/timeflow/data/rates.py
@@ -18,9 +18,7 @@ class Rate(TypedDict):
 
 def rate_active_by_user_client(user_id: int, client_id: int) -> List[Dict]:
     api = f"{base_url}/api/rates/users/{user_id}/clients/{client_id}/"
-    print(api)
     response = requests.get(api)
-    print(response)
     rows = []
     for item in response.json():
         d = {

--- a/applications/timeflow/data/users.py
+++ b/applications/timeflow/data/users.py
@@ -137,3 +137,14 @@ def users_names_inactive(label="select user") -> List[Select]:
         d = Select(value=item["id"], display_value=item["username"])
         username_rows.append(d)
     return username_rows
+
+
+def get_user_id_by_username(username):
+    """
+    Get user id by username.
+    """
+    api = f"{base_url}/api/users"
+    params = {"username": username}
+    response = requests.get(api, params=params).json()
+    user_id = response[0]["id"]
+    return user_id

--- a/applications/timeflow/index.py
+++ b/applications/timeflow/index.py
@@ -28,10 +28,8 @@ menu_items = {
     "Clients": "Clients",
     "Rates": "Rates",
     "Capacities": "Capacities",
-    "Demands": "Demands"
-    
+    "Demands": "Demands",
 }
-
 
 
 @component
@@ -44,7 +42,6 @@ def timeflow():
 
     current_page, set_current_page = use_state("Timelogs")
     pages = ["Timelogs"]
-
 
     if current_page == "Users":
         if user_role == "admin" or user_role == None:
@@ -59,7 +56,9 @@ def timeflow():
         if user_role == "admin" or user_role == None:
             current_page_component = epic_areas_page(key="epic_areas_page")
     elif current_page == "Timelogs":
-        current_page_component = timelogs_page(key="timelogs_page")
+        current_page_component = timelogs_page(
+            key="timelogs_page", app_role=user_role, github_username=github_username
+        )
     elif current_page == "Clients":
         if user_role == "admin" or user_role == None:
             current_page_component = clients_page(key="clients_page")
@@ -75,7 +74,7 @@ def timeflow():
     elif current_page == "Sponsors":
         if user_role == "admin" or user_role == None:
             current_page_component = sponsors_page(key="sponsors_page")
-    elif current_page == "Capacities":      
+    elif current_page == "Capacities":
         if user_role == "admin" or user_role == None:
             current_page_component = capacities_page(key="capacities_page")
     elif current_page == "Demands":

--- a/applications/timeflow/pages/epic_areas.py
+++ b/applications/timeflow/pages/epic_areas.py
@@ -25,7 +25,6 @@ def page():
     submitted_name, set_submitted_name = use_state("")
     _, set_deact_name = use_state("")
     _, set_activ_name = use_state("")
-    print(name)
 
     return html.div(
         {"class": "w-full"},

--- a/applications/timeflow/pages/epics.py
+++ b/applications/timeflow/pages/epics.py
@@ -1,5 +1,6 @@
 from applications.timeflow.pages.utils import switch_state
 from idom import html, use_state, component, event
+from idom.backend import fastapi
 import requests
 from datetime import datetime
 

--- a/applications/timeflow/pages/timelogs.py
+++ b/applications/timeflow/pages/timelogs.py
@@ -1,9 +1,12 @@
-from idom import html, use_state, component, event, vdom
+from idom import html, use_state, component, event
+from idom.backend import fastapi
 import requests
 from datetime import datetime
+from applications.timeflow.config import get_user, fetch_username
 from uiflow.components.input import (
     Input,
     Selector2,
+    display_value,
 )
 from uiflow.components.layout import Row, Column, Container
 from uiflow.components.table import SimpleTable
@@ -12,14 +15,15 @@ from uiflow.components.heading import H3
 
 from ..data.common import (
     year_month_dict_list,
-    username,
     hours,
+    username,
     days_in_month,
 )
 
-from ..data.timelogs import to_timelog, timelog_by_user_id
 from ..data.epics import epics_names
-from ..data.epic_areas import epic_areas_names, epic_areas_names_by_epic_id
+from ..data.epic_areas import epic_areas_names_by_epic_id
+from ..data.timelogs import to_timelog, timelog_by_user_id
+from ..data.users import get_user_id_by_username
 
 from ..config import base_url
 from uiflow.components.controls import TableActions
@@ -28,7 +32,17 @@ from .utils import switch_state
 
 
 @component
-def page():
+def page(app_role: str, github_username: str):
+    """
+    Timelogs page.
+
+    Parameters
+    ----------
+    app_role: str
+        Role of user within the app.
+    github_username: str
+        GitHub username of user.
+    """
     year_month, set_year_month = use_state("")
     day, set_day = use_state("")
     user_id, set_user_id = use_state("")
@@ -57,10 +71,12 @@ def page():
             set_end_time,
             is_event,
             set_is_event,
+            app_role,
+            github_username,
         ),
         Container(
             Column(
-                Row(timelogs_table(user_id, is_event)),
+                Row(timelogs_table(user_id, is_event, app_role, github_username)),
             ),
             delete_timelog_input(set_deleted_timelog),
         ),
@@ -85,6 +101,8 @@ def create_timelog_form(
     set_end_time,
     is_event,
     set_is_event,
+    app_role,
+    github_username,
 ):
     """
     schema:
@@ -124,7 +142,13 @@ def create_timelog_form(
         switch_state(is_event, set_is_event)
         set_epic_id("")
 
-    selector_user = Selector2(set_value=set_user_id, data=username())
+    admin = True if app_role == "admin" or app_role == None else False
+
+    if admin == True:
+        selector_user = Selector2(set_value=set_user_id, data=username())
+    elif admin == False:
+        user_id = get_user_id_by_username(github_username)
+        selector_user = display_value(user_id, github_username)
 
     selector_epic_id = Selector2(
         set_value=set_epic_id,
@@ -156,7 +180,8 @@ def create_timelog_form(
     )
     is_disabled = True
     if (
-        user_id != ""
+        admin == True
+        and user_id != ""
         and epic_id != ""
         and epic_area_id != (0 or "")
         and year_month != ""
@@ -165,7 +190,17 @@ def create_timelog_form(
         and end_time != ""
     ):
         is_disabled = False
-
+    elif (
+        admin == False
+        and epic_id != ""
+        and epic_id != ""
+        and epic_area_id != (0 or "")
+        and year_month != ""
+        and day != ""
+        and start_time != ""
+        and end_time != ""
+    ):
+        is_disabled = False
     btn = Button(is_disabled, handle_submit, label="Submit")
     return html.section(
         {"class": "bg-filter-block-bg py-4 text-sm"},
@@ -189,9 +224,13 @@ def create_timelog_form(
 
 
 @component
-def timelogs_table(user_id, is_event):
+def timelogs_table(user_id, is_event, app_role, github_username):
     api = f"{base_url}/api/timelogs"
     response = requests.get(api)
+    admin = True if app_role == "admin" or app_role == None else False
+
+    if admin == False:
+        user_id = get_user_id_by_username(github_username)
 
     if user_id != "":
         rows = timelog_by_user_id(user_id)

--- a/applications/timeflow/pages/users.py
+++ b/applications/timeflow/pages/users.py
@@ -127,7 +127,6 @@ def update_users(is_event, set_is_event):
 def deactivate_users(is_event, set_is_event):
     """Deactivate an user without deleting it."""
     deactiv_user_id, set_deactiv_user_id = use_state("")
-    print("deactiv iser id is", deactiv_user_id)
 
     def handle_deactivation(event):
         """Set the given user's is_active column to False."""
@@ -153,7 +152,6 @@ def deactivate_users(is_event, set_is_event):
 def activate_users(is_event, set_is_event):
     """Activate an user without deleting it."""
     activ_user_id, set_activ_user_id = use_state("")
-    print("activ iser id is", activ_user_id)
 
     def handle_activation(event):
         """Set the given user's is_active column to False."""

--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -75,6 +75,18 @@ async def get_users(
             .where(AppUser.is_active == is_active)
             .order_by(AppUser.start_date.desc())
         )
+    elif username != None:
+        statement = (
+            select(
+                AppUser.id,
+                AppUser.username,
+                AppUser.first_name,
+                AppUser.last_name,
+                AppUser.start_date,
+            )
+            .select_from(AppUser)
+            .where(AppUser.username == username)
+        )
     result = session.exec(statement).all()
     return result
 

--- a/uiflow/components/input.py
+++ b/uiflow/components/input.py
@@ -90,18 +90,25 @@ def Selector(
 
 @component
 def Selector2(
-    set_value: Callable, data: List, width: str = "14%", md_width: str = "121px", set_sel_value: Callable = None, sel_value: Any = None,
+    set_value: Callable,
+    data: List,
+    width: str = "14%",
+    md_width: str = "121px",
+    set_sel_value: Callable = None,
+    sel_value: Any = None,
 ):
     options = []
     for row in data:
         option = html.option({"value": row["value"]}, row["display_value"])
         options.append(option)
+
     @event()
     async def on_change(event):
         set_value(event["target"]["value"])
         if (set_sel_value and sel_value) != None:
-            set_sel_value(sel_value) 
+            set_sel_value(sel_value)
         return True
+
     return html.div(
         {
             "class": f"block relative w-full sm:w-[48%] md:w-[{md_width}] md:mr-2 my-4 before:content-[''] before:border-[6px] before:border-[transparent] before:border-t-appearance before:top-1/2 before:right-5 before:-translate-y-0.5 before:absolute xl:w-[{width}] 2xl:mr-0"
@@ -114,6 +121,7 @@ def Selector2(
             options,
         ),
     )
+
 
 def SelectorDropdownKeyValue(rows: List[Any]):
     crows = []
@@ -182,5 +190,26 @@ def Checkbox(value_checkbox, handle_change):
                 "onChange": lambda event: handle_change(event),
                 "type": "checkbox",
             }
+        ),
+    )
+
+
+@component
+def display_value(id, value):
+    """
+    Display a value in a selector-like style.
+
+    Parameters
+    ----------
+    id: int
+        Id of the value to be displayed
+    """
+    return html.div(
+        {
+            "class": "py-3 pl-3 w-full border-[1px] sm:w-[48%] md:w-[121px] bg-nav rounded-[3px] md:mr-2 my-4 before:content-[''] before:border-[6px] before:border-[transparent] before:top-1/2 before:right-5 before:-translate-y-0.5 before:absolute xl:w-[14%]",
+        },
+        html.h3(
+            {"value": id},
+            value,
         ),
     )


### PR DESCRIPTION
Allow only for admins to be able to view timelogs of all users, and to post new timelogs for any user.
Users can only see their own timelogs and their username is automatically selected.

Close #270 