### PR TITLE
#307 |Pages||All| Full names only visible on frontend 

### DIFF
--- a/applications/timeflow/data/demands.py
+++ b/applications/timeflow/data/demands.py
@@ -46,7 +46,7 @@ def demands_all():
         d = {
             "demand id": item["demand_id"],
             "team": item["team_short_name"],
-            "epic": item["epic_short_name"],
+            "epic": item["epic_name"],
             "year": item["year"],
             "month": item["month"],
             "demand days": item["days"],
@@ -63,7 +63,7 @@ def demands_by_team(team_id) -> List[Dict]:
         d = {
             "demand id": item["demand_id"],
             "team": item["team_short_name"],
-            "epic": item["epic_short_name"],
+            "epic": item["epic_name"],
             "year": item["year"],
             "month": item["month"],
             "demand days": item["days"],
@@ -80,7 +80,7 @@ def demands_by_team_epic(team_id, epic_id) -> List[Dict]:
         d = {
             "demand id": item["demand_id"],
             "team": item["team_short_name"],
-            "epic": item["epic_short_name"],
+            "epic": item["epic_name"],
             "year": item["year"],
             "month": item["month"],
             "demand days": item["days"],
@@ -97,7 +97,7 @@ def demands_by_epic(epic_id) -> List[Dict]:
         d = {
             "demand id": item["demand_id"],
             "team": item["team_short_name"],
-            "epic": item["epic_short_name"],
+            "epic": item["epic_name"],
             "year": item["year"],
             "month": item["month"],
             "demand days": item["days"],

--- a/backend/api/demand.py
+++ b/backend/api/demand.py
@@ -73,7 +73,7 @@ async def get_demands(
             select(
                 Demand.id.label("demand_id"),
                 Team.short_name.label("team_short_name"),
-                Epic.short_name.label("epic_short_name"),
+                Epic.name.label("epic_name"),
                 Demand.year,
                 Demand.month,
                 Demand.days,
@@ -91,7 +91,7 @@ async def get_demands(
             select(
                 Demand.id.label("demand_id"),
                 Team.short_name.label("team_short_name"),
-                Epic.short_name.label("epic_short_name"),
+                Epic.name.label("epic_name"),
                 Demand.year,
                 Demand.month,
                 Demand.days,

--- a/backend/api/forecast.py
+++ b/backend/api/forecast.py
@@ -56,7 +56,7 @@ async def get_forecasts(session: Session = Depends(get_session)):
         select(
             Forecast.id.label("forecast_id"),
             AppUser.username,
-            Epic.short_name.label("epic_name"),
+            Epic.name.label("epic_name"),
             Forecast.year,
             Forecast.month,
             Forecast.days.label("forecast_days"),

--- a/backend/api/timelog.py
+++ b/backend/api/timelog.py
@@ -95,7 +95,7 @@ async def get_timelogs_all(session: Session = Depends(get_session)):
         select(
             TimeLog.id,
             AppUser.username.label("username"),
-            Epic.short_name.label("epic_name"),
+            Epic.name.label("epic_name"),
             EpicArea.name.label("epic_area_name"),
             TimeLog.start_time,
             TimeLog.end_time,


### PR DESCRIPTION
I've replaced short names with full names in timelogs, forecasts and demands. 
Closes #307 issue.