### PR TITLE
#338 Add deactivate and activate option to Sponsors tab 

### DIFF
--- a/applications/timeflow/data/sponsors.py
+++ b/applications/timeflow/data/sponsors.py
@@ -2,7 +2,6 @@ import requests
 import json
 from typing import List
 
-from uiflow.components.input import display_value
 
 from ..config import base_url
 from datetime import datetime

--- a/applications/timeflow/data/sponsors.py
+++ b/applications/timeflow/data/sponsors.py
@@ -2,6 +2,8 @@ import requests
 import json
 from typing import List
 
+from uiflow.components.input import display_value
+
 from ..config import base_url
 from datetime import datetime
 from .common import Select
@@ -25,7 +27,7 @@ def post_sponsor(name: str, short_name: str, client_id: int):
 
 def get_active_sponsor_rows():
     """Get all active sponsor and store them in a list."""
-    api = f"{base_url}/api/sponsors/active"
+    api = f"{base_url}/api/sponsors/"
     response = requests.get(api)
 
     rows = []
@@ -35,11 +37,22 @@ def get_active_sponsor_rows():
             "Sponsor name": item["sponsor_name"],
             "Sponsor short name": item["sponsor_short_name"],
             "Client name": item["client_name"],
-
+            "Is active": item["is_active"],
         }
         rows.append(d)
 
     return rows
+
+
+def sponsor_names(is_active: bool = None, label="select sponsor") -> List[Select]:
+    api = f"{base_url}/api/sponsors/"
+    params = {"is_active": is_active}
+    response = requests.get(api, params=params)
+    sponsors_rows = [Select(value="", display_value=label)]
+    for item in response.json():
+        d = Select(value=item["id"], display_value=item["sponsor_name"])
+        sponsors_rows.append(d)
+    return sponsors_rows
 
 
 def sponsors_id_name() -> List[Select]:
@@ -49,11 +62,12 @@ def sponsors_id_name() -> List[Select]:
     Returns:
         List[Select]: list of dictionaries
     """
-    api = f"{base_url}/api/sponsors/active"
-    response = requests.get(api)
+    api = f"{base_url}/api/sponsors/"
+    params = {"is_active": True}
+    response = requests.get(api, params=params)
     rows = [Select(value="", display_value="select sponsor")]
     for item in response.json():
-        d = Select(value=item["id"], display_value=item["sponsor_short_name"])
+        d = Select(value=item["id"], display_value=item["sponsor_name"])
         rows.append(d)
     return rows
 

--- a/applications/timeflow/pages/sponsors.py
+++ b/applications/timeflow/pages/sponsors.py
@@ -4,6 +4,7 @@ from uiflow.components.controls import (
     activation_button,
     deactivation_button,
     submit_button,
+    Button,
 )
 from uiflow.components.input import Input, Selector2
 from uiflow.components.layout import Row, Column, Container
@@ -14,6 +15,7 @@ from ..data.sponsors import (
     post_sponsor,
     sponsor_activation,
     sponsor_deactivation,
+    sponsor_names,
 )
 from ..data.clients import clients_names
 
@@ -145,17 +147,19 @@ def deactivate_sponsor(set_deact_name):
         set_deact_name(name_to_deact)
 
     # Create input field for name of sponsor to be deactivated
-    inp_deact_name = Input(
-        set_value=set_name_to_deact,
-        label="sponsor to be deactivated",
-        width="full",
-        md_width="full",
+    sponsors_selector_deact = Selector2(
+        set_name_to_deact,
+        data=sponsor_names(is_active=True, label="sponsor to be deactivated"),
+        width="96%",
+        md_width="96%",
     )
 
     # Create the deactivation button
-    btn = deactivation_button(name_to_deact, handle_deactivation)
-
-    return Column(Row(inp_deact_name), Row(btn))
+    is_disabled = True
+    if name_to_deact != "":
+        is_disabled = False
+    btn = Button(is_disabled, handle_submit=handle_deactivation, label="Deactivate")
+    return Column(Row(sponsors_selector_deact), Row(btn))
 
 
 @component
@@ -169,14 +173,16 @@ def activate_sponsor(set_activ_name):
         set_activ_name(name_to_activ)
 
     # Create input field for name of sponsor to be activated
-    inp_activ_name = Input(
-        set_value=set_name_to_activ,
-        label="sponsor to be activated",
-        width="full",
-        md_width="full",
+    sponsors_selector_act = Selector2(
+        set_name_to_activ,
+        data=sponsor_names(is_active=False, label="sponsor to be activated"),
+        width="96%",
+        md_width="96%",
     )
 
     # Create the activation button
-    btn = activation_button(name_to_activ, handle_activation)
-
-    return Column(Row(inp_activ_name), Row(btn))
+    is_disabled = True
+    if name_to_activ != "":
+        is_disabled = False
+    btn = Button(is_disabled, handle_submit=handle_activation, label="Activate")
+    return Column(Row(sponsors_selector_act), Row(btn))


### PR DESCRIPTION
Added "is active" column to sponsors tab and drop-down lists to deactivate or activate sponsor. 
If sponsor will be deactivated True in the table will change to False (vice versa) and it won't show in the Epics tab sponsor selector.
Closes #338 issue.
![image](https://user-images.githubusercontent.com/60892276/170480698-1f707fac-44a4-4dfd-b4e6-544f75e0ba64.png)
![image](https://user-images.githubusercontent.com/60892276/170481063-6d208e20-c8e3-497c-8835-0654a3c2aa47.png)
