### PR TITLE
✨ |Pages||Capacities| Capacities eabled for users  

### DIFF
--- a/applications/timeflow/data/capacities.py
+++ b/applications/timeflow/data/capacities.py
@@ -68,6 +68,28 @@ def capacities_by_user(user_id: int) -> List[Dict]:
     return rows
 
 
+def capacities_by_user_year_month(user_id, year_month) -> List[Dict]:
+    if user_id != "" and year_month != "":
+        api = f"{base_url}/api/capacities/users/{user_id}"
+        params = {
+            "year": int(year_month[:4]),
+            "month": int(year_month[5:7]),
+        }
+
+        response = requests.get(api, params=params)
+        rows = []
+        for item in response.json():
+            d = {
+                "capacity id": item["capacity_id"],
+                "user": item["last_name"] + " " + item["first_name"],
+                "year": item["year"],
+                "month": item["month"],
+                "capacity days": item["days"],
+            }
+            rows.append(d)
+        return rows
+
+
 def capacity_days() -> List[Dict]:
     days = [Select(value="", display_value="select capacity days")]
     for item in capacity_days_list:

--- a/applications/timeflow/data/forecasts.py
+++ b/applications/timeflow/data/forecasts.py
@@ -53,6 +53,27 @@ def forecasts_by_user(user_id: int) -> List[Dict]:
     return rows
 
 
+def forecasts_by_user_year_month(user_id: int, year_month: str) -> List[Dict]:
+    api = f"{base_url}/api/forecasts/users/{user_id}"
+    params = {
+        "year": int(year_month[:4]),
+        "month": int(year_month[5:7]),
+    }
+    response = requests.get(api, params)
+    rows = []
+    for item in response.json():
+        d = {
+            "FORECAST ID": item["forecast_id"],
+            "USER": item["last_name"] + " " + item["first_name"],
+            "EPIC NAME": item["epic_name"],
+            "YEAR": item["year"],
+            "MONTH": item["month"],
+            "DAYS": item["forecast_days"],
+        }
+        rows.append(d)
+    return rows
+
+
 def forecast_days() -> List[Dict]:
     days = [Select(value="", display_value="select days")]
     for item in forecast_days_list:
@@ -83,7 +104,7 @@ def to_forecast(user_id: int, epic_id: int, month: str, year: str, days: int) ->
         data=json.dumps(dict(data)),
         headers={"accept": "application/json", "Content-Type": "application/json"},
     )
-    return True
+    return response.json()
 
     # user_id=user_id,
     # client_id=client_id,

--- a/applications/timeflow/data/users.py
+++ b/applications/timeflow/data/users.py
@@ -131,6 +131,13 @@ def users_names(is_active: bool = None, label="select user") -> List[Select]:
     return rows
 
 
+def user_full_name_by_id(user_id):
+    api = f"{base_url}/api/users/{user_id}"
+    response = requests.get(api)
+    full_name = response.json()[0]["last_name"] + " " + response.json()[0]["first_name"]
+    return full_name
+
+
 def get_user_id_by_username(username):
     """
     Get user id by username.

--- a/applications/timeflow/index.py
+++ b/applications/timeflow/index.py
@@ -27,7 +27,6 @@ menu_items = {
     "Sponsors": "Sponsors",
     "Clients": "Clients",
     "Rates": "Rates",
-    "Capacities": "Capacities",
     "Demands": "Demands",
 }
 
@@ -39,7 +38,7 @@ def timeflow():
     # Get user's github username
     github_username = fetch_username()
     current_page, set_current_page = use_state("Timelogs")
-    pages = ["Timelogs"]
+    pages = ["Timelogs", "Capacities"]
 
     if current_page == "Users":
         if user_role == "admin" or user_role == None:
@@ -84,10 +83,12 @@ def timeflow():
                 key="sponsors_page", key_attr="sponsors_page"
             )
     elif current_page == "Capacities":
-        if user_role == "admin" or user_role == None:
-            current_page_component = capacities_page(
-                key="capacities_page", key_attr="capacities_page"
-            )
+        current_page_component = capacities_page(
+            key="capacities_page",
+            key_attr="capacities_page",
+            app_role=user_role,
+            github_username=github_username,
+        )
     elif current_page == "Demands":
         if user_role == "admin" or user_role == None:
             current_page_component = demands_page(

--- a/applications/timeflow/pages/capacities.py
+++ b/applications/timeflow/pages/capacities.py
@@ -2,7 +2,7 @@ from idom import html, use_state, component, event
 
 from .utils import switch_state
 
-from uiflow.components.input import Input, Selector, display_value
+from uiflow.components.input import Input, Selector, display_value, InputMonth
 from uiflow.components.layout import Row, Column, Container
 
 from uiflow.components.table import SimpleTable
@@ -97,11 +97,8 @@ def create_capacity_form(
         user_id = get_user_id_by_username(github_username)
         selector_user_id = display_value(user_id, github_username)
 
-    selector_year_month = Selector(
+    input_year_month = InputMonth(
         set_value=set_year_month,
-        data=year_month_dict_list(),
-        width="24%",
-        md_width="24%",
     )
 
     selector_days = Selector(
@@ -118,7 +115,7 @@ def create_capacity_form(
         Column(
             Row(
                 selector_user_id,
-                selector_year_month,
+                input_year_month,
                 selector_days,
                 justify="justify-between",
             ),

--- a/applications/timeflow/pages/clients.py
+++ b/applications/timeflow/pages/clients.py
@@ -5,8 +5,8 @@ import requests
 from datetime import datetime
 
 from uiflow.components.input import Input, Selector
-from uiflow.components.layout import Row, Column, Container
-from uiflow.components.table import SimpleTable, SubmitTable
+from uiflow.components.layout import Row, Column, FlexContainer, Container
+from uiflow.components.table import SimpleTable
 from uiflow.components.controls import Button
 
 from ..config import base_url

--- a/applications/timeflow/pages/utils.py
+++ b/applications/timeflow/pages/utils.py
@@ -35,7 +35,7 @@ for n in days_in_month_nr:
 
 
 capacity_days_list = []
-capacity_days_nr = range(1, 21)
+capacity_days_nr = range(1, 29)
 for n in capacity_days_nr:
     capacity_days_list.append(n)
 

--- a/backend/api/capacity.py
+++ b/backend/api/capacity.py
@@ -4,7 +4,6 @@ from ..models.capacity import Capacity
 from sqlmodel import Session, select, and_
 from sqlalchemy.exc import NoResultFound
 from ..models.user import AppUser
-from ..models.team import Team
 
 router = APIRouter(prefix="/api/capacities", tags=["capacity"])
 
@@ -68,7 +67,6 @@ async def get_capacities(
         Capacity.id.label("capacity_id"),
         AppUser.last_name,
         AppUser.first_name,
-        Team.name.label("team_name"),
         Capacity.year,
         Capacity.month,
         Capacity.days,
@@ -88,7 +86,12 @@ async def get_capacities(
 
 
 @router.get("/users/{user_id}/")
-async def get_capacities_user(user_id: int, session: Session = Depends(get_session)):
+async def get_capacities_user(
+    user_id: int,
+    session: Session = Depends(get_session),
+    year: str = None,
+    month: str = None,
+):
     """
     Get list of capacities by user_id.
 
@@ -113,8 +116,14 @@ async def get_capacities_user(user_id: int, session: Session = Depends(get_sessi
         .join(AppUser, Capacity.user_id == AppUser.id)
         .where(Capacity.user_id == user_id)
     )
+    if year != None and month != None:
+        statement_final = statement.where(Capacity.year == year).where(
+            Capacity.month == month
+        )
+    else:
+        statement_final = statement
 
-    result = session.exec(statement).all()
+    result = session.exec(statement_final).all()
     return result
 
 

--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -91,6 +91,27 @@ async def get_users(
     return result
 
 
+@router.get("/{user_id}")
+async def get_user_by_id(user_id: int, session: Session = Depends(get_session)):
+    statement = (
+        select(
+            AppUser.id,
+            AppUser.username,
+            AppUser.first_name,
+            AppUser.last_name,
+            Role.name.label("role_name"),
+            Team.short_name.label("main_team"),
+            AppUser.start_date,
+            AppUser.is_active,
+        )
+        .select_from(AppUser)
+        .join(Role, AppUser.role_id == Role.id, isouter=True)
+        .join(Team, AppUser.team_id == Team.id, isouter=True)
+    ).where(AppUser.id == user_id)
+    result = session.exec(statement).all()
+    return result
+
+
 @router.put("/{user_id}/")
 async def update_user(
     user_id: int,

--- a/uiflow/components/input.py
+++ b/uiflow/components/input.py
@@ -198,6 +198,28 @@ def InputDate(set_value):
 
 
 @component
+def InputMonth(
+    set_value,
+    set_sel_value: Callable = None,
+    sel_value: Any = None,
+):
+    @event()
+    async def on_change(event):
+        set_value(event["target"]["value"])
+        if (set_sel_value and sel_value) != None:
+            set_sel_value(sel_value)
+        return True
+
+    return html.input(
+        {
+            "class": "py-3 pl-3 w-full border-[1px] sm:w-[48%] md:w-[121px] bg-nav rounded-[3px] md:mr-2 my-4 before:content-[''] before:border-[6px] before:border-[transparent] before:top-1/2 before:right-5 before:-translate-y-0.5 before:absolute xl:w-[14%]",
+            "type": "month",
+            "onChange": on_change,
+        },
+    )
+
+
+@component
 def display_value(id, value):
     """
     Display a value in a selector-like style.

--- a/uiflow/components/table.py
+++ b/uiflow/components/table.py
@@ -54,7 +54,6 @@ def SimpleTable(rows: List[Any]):
             {"class": "overflow-auto py-6 text-xs"},
             html.table({"class": "w-[905px] mx-auto xl:w-full"}, thead, tbody),
         )
-
         return html.div(
             {"class": "flex flex-col w-full space-y-2"},
             table,
@@ -75,32 +74,42 @@ def SimpleTable(rows: List[Any]):
 
 
 @component
-def SubmitTable(rows: List[Any]):
-    trs = []
-    for row in rows[-5:]:
-        tds = []
-        for k in row:
-            value = row[k]
-            tds.append(html.td({"class": "p-4 w-full"}, value))
-        trs.append(html.tr({"class": "flex w-full mb-4"}, tds))
+def DisplayTable(rows: List[Any]):
+    try:
+        trs = []
+        for row in rows:
+            tds = []
 
-    ths = [html.th({"class": thClass}, header) for header in rows[0].keys()]
-    thead = html.thead(
-        {"class": ""},
-        html.tr({"class": "bg-table-head"}, ths),
-    )
-    tbody = html.tbody(
-        {
-            "class": "flex flex-col bg-secondary-200 items-center justify-between overflow-y-scroll w-full"
-        },
-        trs,
-    )
-    table = html.table({"class": "w-[905px] mx-auto xl:w-full"}, thead, tbody)
+            for k in row:
+                value = row[k]
+                tds.append(html.td({"class": tdClassActive}, value))
 
-    return html.div(
-        {"class": "flex flex-col w-full space-y-2"},
-        table,
-    )
+            trs.append(
+                html.tr(
+                    {"class": trClass},
+                    tds,
+                )
+            )
+
+        ths = [html.th({"class": thClass}, header) for header in rows[0].keys()]
+        thead = html.thead(
+            html.tr({"class": "bg-table-head"}, ths),
+        )
+        tbody = html.tbody(
+            trs,
+        )
+        table = html.div(
+            {"class": "overflow-auto py-6 text-xs"},
+            html.table({"class": "w-[905px] mx-auto xl:w-full"}, thead, tbody),
+        )
+        return html.div(
+            {"class": "flex flex-col w-full space-y-2"},
+            table,
+        )
+    except TypeError:
+        return html.div()
+    except IndexError:
+        return html.div()
 
 
 @component


### PR DESCRIPTION
Capacities page:
- capacities moved outside admin collapse
- users can add their own capacities
- user selector available only for `admin` role
Forecasts page:
- added new table `capacities_table` which is visible after selecting user and month
- added filtering of `forecasts_table` by user and month
- changed order of visible forecasts to ascending and month start > current month
Components:
- created a new component `DisplayTable` for displaying raw rows
- deleted `SubmitTable` component

- added changes to corresponding files around timeflow code
- closes https://github.com/dyvenia/timeflow/issues/395

![image](https://user-images.githubusercontent.com/88193723/177547864-53b020a0-7114-4f43-819e-055e5a87a27a.png)

