### PR TITLE
✨ Added forecasts table to see total forecasted days per month per epic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17] - 2022-08-12
+### Added
+- Added feature for admins to see total forecasts days per selected month & year 
+    for selected epic on `Forecasts` page
 ## [0.1.12] - 2022-07-11
 ### Added
 - Added feature for users to see response message on submit click on `Capacities` page

--- a/applications/timeflow/data/forecasts.py
+++ b/applications/timeflow/data/forecasts.py
@@ -74,6 +74,26 @@ def forecasts_by_user_year_month(user_id: int, year_month: str) -> List[Dict]:
     return rows
 
 
+def forecasts_days_sum_by_epic_month_year(epic_id: int, year_month: str) -> List[Dict]:
+    api = f"{base_url}/api/forecasts"
+    params = {
+        "epic_id": epic_id,
+        "year": int(year_month[:4]),
+        "month": int(year_month[5:7]),
+    }
+    response = requests.get(api, params)
+    rows = []
+    for item in response.json():
+        d = {
+            "EPIC NAME": item["epic_name"],
+            "YEAR": item["year"],
+            "MONTH": item["month"],
+            "TOTAL DAYS": item["forecast_days_sum"],
+        }
+        rows.append(d)
+    return rows
+
+
 def forecast_days() -> List[Dict]:
     days = [Select(value="", display_value="select days")]
     for item in forecast_days_list:

--- a/applications/timeflow/pages/forecasts.py
+++ b/applications/timeflow/pages/forecasts.py
@@ -16,6 +16,7 @@ from ..data.forecasts import (
     forecast_days,
     to_forecast,
     forecast_deletion,
+    forecasts_days_sum_by_epic_month_year,
 )
 from ..data.capacities import capacities_by_user_year_month
 
@@ -53,7 +54,7 @@ def page(key_attr: str):
         Container(capacities_table(user_id, year_month)),
         Container(
             Column(
-                Row(forecasts_table(user_id, year_month)),
+                Row(forecasts_table(user_id, epic_id, year_month)),
             )
         ),
         Container(
@@ -223,7 +224,7 @@ def capacities_table(user_id, year_month):
 
 
 @component
-def forecasts_table(user_id, year_month):
+def forecasts_table(user_id, epic_id, year_month):
     """Generates a table component with forecast days by year and month
 
     Args:
@@ -238,8 +239,10 @@ def forecasts_table(user_id, year_month):
     rows = forecasts_all()
     if user_id != "" and year_month != "":
         rows = forecasts_by_user_year_month(user_id, year_month)
-    elif user_id != "":
+    elif user_id != "" and year_month == "":
         rows = forecasts_by_user(user_id)
+    elif user_id == "" and year_month != "" and epic_id != "":
+        rows = forecasts_days_sum_by_epic_month_year(epic_id, year_month)
     return Column(
         H3("Selected forecasts"),
         html.div({"class": "flex w-full"}, SimpleTable(rows=rows)),

--- a/backend/api/forecast.py
+++ b/backend/api/forecast.py
@@ -96,6 +96,7 @@ async def get_forecasts(
             statement.order_by(Forecast.year.asc())
             .where(Forecast.year >= datetime.now().year)
             .where(Forecast.month >= datetime.now().month)
+            .order_by(Forecast.year.asc())
             .order_by(Forecast.month.asc())
         )
 


### PR DESCRIPTION
Added a new filter to see summed up forecast days for selected epic, month, and year. User selector must be deselected.
- closes https://github.com/dyvenia/timeflow/issues/458 
   and https://github.com/dyvenia/timeflow/issues/459