### PR TITLE
Fixed changing and updating data

### DIFF
--- a/frontend/src/routes/capacities/+page.svelte
+++ b/frontend/src/routes/capacities/+page.svelte
@@ -31,7 +31,7 @@
 	let time = '';
 
 	onMount(async () => {
-		users = await getUsers();
+		users = await getUsers(true);
 	});
 	onMount(async () => {
 		capacities = await getCapacities(capacities);

--- a/frontend/src/routes/data/+server.js
+++ b/frontend/src/routes/data/+server.js
@@ -1,5 +1,6 @@
 import { env } from '$env/dynamic/public'
 
+
 export const baseUrl = env.PUBLIC_SVELTEKIT_DEV_BASE_URL
 /**
  * @param {any} timelogs
@@ -11,13 +12,23 @@ async function getTimelogs(timelogs) {
     });
     timelogs = await response.json();
     return timelogs;
-}
-
-async function getUsers() {
-    const response = await fetch(`${baseUrl}/api/users/`, {
-        method: 'GET',
-        headers: { 'Content-type': 'application/json' }
-    });
+};
+/**
+ * @param {boolean} is_active
+ */
+async function getUsers(is_active) {
+    let response
+    if (is_active === true) {
+        response = await fetch(`${baseUrl}/api/users/?is_active=${is_active}`, {
+            method: 'GET',
+            headers: { 'Content-type': 'application/json' }
+        });
+    } else {
+        response = await fetch(`${baseUrl}/api/users/`, {
+            method: 'GET',
+            headers: { 'Content-type': 'application/json' }
+        });
+    }
     let users = await response.json()
     return users
 };

--- a/frontend/src/routes/epics/+page.svelte
+++ b/frontend/src/routes/epics/+page.svelte
@@ -12,23 +12,23 @@
 	let selectedRowIds: Array<string> = [];
 	let newEpicsFullName: string;
 	let newEpicsShortName: string;
-	let columnsToEdit = {
-		epic_name: 'input',
-		short_name: 'input',
-		is_active: 'toggle',
-		team_name: {
-			input: 'autocomplete',
-			selectDisplay: 'team_name',
-			options: teams,
-			placeholder: "team's name"
-		},
-		sponsor_name: {
-			input: 'autocomplete',
-			selectDisplay: 'sponsor_name',
-			options: sponsors,
-			placeholder: "sponsor's name"
-		}
-	};
+	// let columnsToEdit = {
+	// 	epic_name: 'input',
+	// 	short_name: 'input',
+	// 	is_active: 'toggle',
+	// 	team_name: {
+	// 		input: 'autocomplete',
+	// 		selectDisplay: 'team_name',
+	// 		options: teams,
+	// 		placeholder: "team's name"
+	// 	},
+	// 	sponsor_name: {
+	// 		input: 'autocomplete',
+	// 		selectDisplay: 'sponsor_name',
+	// 		options: sponsors,
+	// 		placeholder: "sponsor's name"
+	// 	}
+	// };
 
 	let selectedTeam: Object = {};
 	let selectedSponsor: Object = {};
@@ -50,6 +50,7 @@
 			headers: { 'Content-type': 'application/json' },
 			body: JSON.stringify({
 				team_id: selectedTeam.id,
+				team_name: selectedTeam.team_name,
 				sponsor_id: selectedSponsor.id,
 				name: newEpicsFullName,
 				short_name: newEpicsShortName,
@@ -117,23 +118,23 @@
 				bind:selectedRowIds
 				bind:updatedData
 				{onUpdate}
-				removeAction={true}
 				columnsToEdit={{
 					epic_name: 'input',
 					short_name: 'input',
 					is_active: 'toggle',
 					team_name: {
-						input: 'autocomplete',
+						type: 'autocomplete',
 						selectDisplay: 'team_name',
 						options: teams,
 						placeholder: "team's name"
 					},
 					sponsor_name: {
-						input: 'autocomplete',
+						type: 'autocomplete',
 						selectDisplay: 'sponsor_name',
 						options: sponsors,
 						placeholder: "sponsor's name"
-					}
+					},
+					start_date: 'date'
 				}}
 			/>
 		</Column>

--- a/frontend/src/routes/forecasts/+page.svelte
+++ b/frontend/src/routes/forecasts/+page.svelte
@@ -16,7 +16,7 @@
 	let selectedMonth: string = '';
 	let updatedData: Array<object> = [];
 	onMount(async () => {
-		users = await getUsers();
+		users = await getUsers(true);
 	});
 	onMount(async () => {
 		epics = await getEpics();
@@ -112,7 +112,7 @@
 				bind:updatedData
 				{onUpdate}
 				{onRemove}
-				columnsToEdit={{ forecast_days: 'input' }}
+				columnsToEdit={{ forecast_days: 'number' }}
 			/>
 		</Column>
 	</Row>

--- a/frontend/src/routes/rates/+page.svelte
+++ b/frontend/src/routes/rates/+page.svelte
@@ -16,10 +16,10 @@
 	let startDate: string;
 	const farDate: string = '9999-12-31';
 	let newRateValidTo: string;
-	let columnsToEdit = {
-		is_active: 'toggle',
-		username: 'input'
-	};
+	// let columnsToEdit = {
+	// 	is_active: 'toggle',
+	// 	username: 'input'
+	// };
 	let updatedData: Array<object> = [];
 	let result: any = null;
 
@@ -28,7 +28,7 @@
 		console.log('rate', rates);
 	});
 	onMount(async () => {
-		users = await getUsers();
+		users = await getUsers(true);
 	});
 	onMount(async () => {
 		clients = await getClients();
@@ -117,10 +117,26 @@
 					{ key: 'is_active', value: 'IS ACTIVE' }
 				]}
 				rows={rates}
-				{columnsToEdit}
 				bind:selectedRowIds
 				bind:updatedData
 				{onUpdate}
+				columnsToEdit={{
+					full_name: {
+						type: 'autocomplete',
+						selectDisplay: 'full_name',
+						options: users,
+						placeholder: 'full name'
+					},
+					name: {
+						type: 'autocomplete',
+						selectDisplay: 'client_name',
+						options: clients,
+						placeholder: "client's name"
+					},
+					valid_from: 'date',
+					valid_to: 'date',
+					is_active: 'toggle'
+				}}
 			/>
 		</Column>
 	</Row>

--- a/frontend/src/routes/roles/+page.svelte
+++ b/frontend/src/routes/roles/+page.svelte
@@ -12,6 +12,7 @@
 	let newRolesShortName: string;
 	let columnsToEdit = ['name', 'short_name', 'is_active'];
 	let updatedData: Array<object> = [];
+	let result: any = null;
 
 	onMount(async () => {
 		roles = await getRoles();
@@ -29,12 +30,15 @@
 				updated_at: Date.now()
 			})
 		});
+		const json = await res.json();
+		result = JSON.stringify(json);
 		roles = await getRoles();
 	}
 	async function onUpdate() {
 		const updateRes = await fetch(`${baseUrl}/api/roles/bulk_update`, {
 			method: 'POST',
-			headers: { 'Content-type': 'application/json' }
+			headers: { 'Content-type': 'application/json' },
+			body: JSON.stringify(updatedData)
 		});
 		roles = await getRoles();
 		updatedData = [];
@@ -65,10 +69,14 @@
 					{ key: 'is_active', value: 'IS ACTIVE' }
 				]}
 				rows={roles}
-				{columnsToEdit}
 				bind:selectedRowIds
 				bind:updatedData
 				{onUpdate}
+				columnsToEdit={{
+					role_name: 'input',
+					short_name: 'input',
+					is_active: 'toggle'
+				}}
 			/>
 		</Column>
 	</Row>

--- a/frontend/src/routes/timelogs/+page.svelte
+++ b/frontend/src/routes/timelogs/+page.svelte
@@ -31,7 +31,7 @@
 	let columnsToEdit = ['start_time', 'end_time'];
 
 	onMount(async () => {
-		users = await getUsers();
+		users = await getUsers(true);
 	});
 	onMount(async () => {
 		epicAreas = await getEpicAreas();

--- a/frontend/src/routes/users/+page.svelte
+++ b/frontend/src/routes/users/+page.svelte
@@ -22,38 +22,6 @@
 	let selectedEpic: Object = {};
 	let updatedData: Array<object> = [];
 
-	let columnsToEdit = {
-		first_name: 'input',
-		last_name: 'input',
-		role_name: {
-			type: 'autocomplete',
-			selectDisplay: 'role_name',
-			options: roles,
-			placeholder: "role's name"
-		},
-		main_team: {
-			type: 'autocomplete',
-			selectDisplay: 'team_name',
-			options: teams,
-			placeholder: "teams's name"
-		},
-		epic_name: {
-			type: 'autocomplete',
-			selectDisplay: 'epic_name',
-			options: roles,
-			placeholder: "epic's name"
-		},
-		supervisor: {
-			type: 'autocomplete',
-			selectDisplay: 'full_name',
-			options: users,
-			placeholder: 'select supervisor'
-		},
-		is_active: 'toggle',
-		email: 'input',
-		start_date: 'date'
-	};
-
 	onMount(async () => {
 		users = await getUsers();
 		columnsToEdit.supervisor.options = users;
@@ -168,7 +136,38 @@
 				bind:selectedRowIds
 				bind:updatedData
 				{onUpdate}
-				bind:columnsToEdit
+				columnsToEdit={{
+					username: 'input',
+					first_name: 'input',
+					last_name: 'input',
+					role_name: {
+						type: 'autocomplete',
+						selectDisplay: 'role_name',
+						options: roles,
+						placeholder: "role's name"
+					},
+					main_team: {
+						type: 'autocomplete',
+						selectDisplay: 'team_name',
+						options: teams,
+						placeholder: "teams's name"
+					},
+					epic_name: {
+						type: 'autocomplete',
+						selectDisplay: 'epic_name',
+						options: roles,
+						placeholder: "epic's name"
+					},
+					supervisor: {
+						type: 'autocomplete',
+						selectDisplay: 'full_name',
+						options: users,
+						placeholder: 'select supervisor'
+					},
+					is_active: 'toggle',
+					email: 'input',
+					start_date: 'date'
+				}}
 			/>
 		</Column>
 	</Row>


### PR DESCRIPTION
- Added 'is_active' parameter to getUsers function
- Enabled adding capacities, rates, timelogs and forecasts for active users only
- Made data in table on epics subpage editable
- Made data in table on forecasts subpage editable
- Made data in table on rates subpage editable
- Made data in table on roles subpage editable and updateable
- Made data in table on users subpage editable